### PR TITLE
Fix for updating stats

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,53 @@
+name: Update GitHub Stats in README
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # workflow to daily at midnight
+  workflow_dispatch:  # Allows manual trigger
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Read Current README.md
+        id: read-file
+        run: |
+          # Extract the first occurrence of cache_seconds value or default to 60 if not found
+          CACHE_SECONDS=$(grep -oP 'cache_seconds=\K\d+' README.md | head -n 1 || echo 60)
+          
+          # Trim any potential leading or trailing spaces
+          CACHE_SECONDS=$(echo "$CACHE_SECONDS" | xargs)
+          
+          echo "Current cache_seconds: $CACHE_SECONDS"
+          
+          # Ensure CACHE_SECONDS is a valid positive number
+          if ! [[ "$CACHE_SECONDS" =~ ^[0-9]+$ ]]; then
+            echo "Invalid cache_seconds value, resetting to 60."
+            CACHE_SECONDS=60
+          fi
+          
+          # Increases cache_seconds by 1
+          NEW_CACHE_SECONDS=$((CACHE_SECONDS + 1))
+          
+          # Store the new value for later steps
+          echo "NEW_CACHE_SECONDS=$NEW_CACHE_SECONDS" >> $GITHUB_ENV
+
+
+
+      - name: Update README.md
+        run: |
+          # Replace all occurrences of cache_seconds in README.md with the new value
+          sed -i "s/cache_seconds=[0-9]\+/cache_seconds=${NEW_CACHE_SECONDS}/g" README.md
+          echo "Updated README.md with cache_seconds=${NEW_CACHE_SECONDS}"
+
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.name "username"
+          git config --global user.email "user_email"
+          git add README.md
+          git commit -m "Auto-update cache_seconds to ${NEW_CACHE_SECONDS}" || echo "No changes to commit"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 <h1 align="center">Hello there, I'm Manuel!</h1>
 
 <h2>Statistics</h2>
-<p align="center"><img align="center" height="165px" src="https://github-readme-stats.vercel.app/api?username=mashb1t&count_private=true&show_icons=true&theme=tokyonight" /><img align="center" height="165px" src="https://github-readme-stats.vercel.app/api/top-langs/?username=mashb1t&layout=compact&theme=aura&langs_count=9" />
+<p align="center">
+  <img align="center" height="165px" src="https://github-readme-stats.vercel.app/api?username=mashb1t&count_private=true&show_icons=true&theme=tokyonight&cache_seconds=21" />
+  <img align="center" height="165px" src="https://github-readme-stats.vercel.app/api/top-langs/?username=mashb1t&layout=compact&theme=aura&langs_count=9&cache_seconds=21" />
 </p>
 <p align="center"><img src="https://raw.githubusercontent.com/mashb1t/mashb1t/output/github-contribution-grid-snake-dark.svg" /></p>
 <br>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 <h1 align="center">Hello there, I'm Manuel!</h1>
 
 <h2>Statistics</h2>
+<p align="center"><img align="center" height="165px" src="https://raw.githubusercontent.com/mashb1t/mashb1t/output/github-stats.svg" /><img align="center" height="165px" src="https://raw.githubusercontent.com/mashb1t/mashb1t/output/github-languages.svg" /></p>
 <p align="center">
-  <img align="center" height="165px" src="https://github-readme-stats.vercel.app/api?username=mashb1t&count_private=true&show_icons=true&theme=tokyonight&cache_seconds=21" />
-  <img align="center" height="165px" src="https://github-readme-stats.vercel.app/api/top-langs/?username=mashb1t&layout=compact&theme=aura&langs_count=9&cache_seconds=21" />
-</p>
-<p align="center"><img src="https://raw.githubusercontent.com/mashb1t/mashb1t/output/github-contribution-grid-snake-dark.svg" /></p>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/mashb1t/mashb1t/output/github-contribution-grid-snake-dark.svg" />
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/mashb1t/mashb1t/output/github-contribution-grid-snake-light.svg" />
+  <img alt="github-snake" src="https://raw.githubusercontent.com/mashb1t/mashb1t/output/github-contribution-grid-snake.svg" />
+</picture>
 <br>
 <h2 align="left" font-weight="bold">About me</h2>
 


### PR DESCRIPTION
Saw that the profile stats were not updating as expected. see attachment images, for the difference.
Different ways found to address the issue:

1. One way to update stats was to add js script that will fetch the latest data from readme stats api https://github-readme-stats.vercel.app/api. But I found out that "GitHub does not support running JavaScript in markdown files"



2. Host GitHub Readme Stats Yourself
GitHub Readme Stats is rate-limited when hosted on Vercel. You can deploy it yourself to ensure real-time updates.
	1.	Fork the repository: https://github.com/anuraghazra/github-readme-stats
	2.	Deploy on Vercel (or any hosting platform)
	4.	Use your own instance URL instead of https://github-readme-stats.vercel.app/


3. **Found this fix, that Uses Github Actions, for keeping profile stats up to date.**

I added update-readme.yml, to handle the logic to update stats, cronjob scheduled for midnight, and manual trigger.
And updated README.md file 

Profile Stats & Actual Stats Images:

<img width="1728" alt="profile_stats" src="https://github.com/user-attachments/assets/f6e20974-5bdb-4796-a14e-712f8f81215e" />
<img width="1122" alt="actual_stats" src="https://github.com/user-attachments/assets/923bc8f6-6c43-4452-9230-b494e856f1f7" />

